### PR TITLE
Fix broken corpus load from JSON

### DIFF
--- a/decomp/semantics/uds/document.py
+++ b/decomp/semantics/uds/document.py
@@ -129,7 +129,7 @@ class UDSDocument:
         edge_attrs
             the edge annotations to be added
         """
-        self.document_graph.add_annotation(node_attrs, edge_attrs)
+        self.document_graph.add_annotation(node_attrs, edge_attrs, self.sentence_ids)
 
     def semantics_node(self, document_node: str) -> Dict[str, Dict]:
         """The semantics node for a given document node


### PR DESCRIPTION
Discovered a bug this morning that causes corpus builds from JSON to fail with the following error:

```
<ipython-input-3-02e072b88873> in <module>
----> 1 uds = UDSCorpus(version="2.0", annotation_format="raw")

~/research/decomp-fork/decomp/semantics/uds/corpus.py in __init__(self, sentences, documents, sentence_annotations, document_annotations, version, split, annotation_format)
     97         elif sentences is None and split is None and all_built:
     98             for split in ['train', 'dev', 'test']:
---> 99                 self._load_split(split)
    100 
    101         elif sentences is None:

~/research/decomp-fork/decomp/semantics/uds/corpus.py in _load_split(self, split)
    210         sentence_fpath = self._sentences_paths[split]
    211         doc_fpath = self._documents_paths[split]
--> 212         split = self.__class__.from_json(sentence_fpath, doc_fpath)
    213 
    214         self._metadata += split.metadata

~/research/decomp-fork/decomp/semantics/uds/corpus.py in from_json(cls, sentences_jsonfile, documents_jsonfile)
    391         documents = {name: UDSDocument.from_dict(d_json, sentences,
    392                                                  sent_ids, name)
--> 393                      for name, d_json in documents_json['data'].items()}
    394 
    395         corpus = cls(sentences, documents)

~/research/decomp-fork/decomp/semantics/uds/corpus.py in <dictcomp>(.0)
    391         documents = {name: UDSDocument.from_dict(d_json, sentences,
    392                                                  sent_ids, name)
--> 393                      for name, d_json in documents_json['data'].items()}
    394 
    395         corpus = cls(sentences, documents)

~/research/decomp-fork/decomp/semantics/uds/document.py in from_dict(cls, document, sentence_graphs, sentence_ids, name)
     76         """
     77         document_graph = UDSDocumentGraph.from_dict(document, name)
---> 78         sent_graph_names = set(map(lambda node: node['semantics']['graph'], document['nodes']))
     79         sent_graphs = {}
     80         sent_ids = {}

~/research/decomp-fork/decomp/semantics/uds/document.py in <lambda>(node)
     76         """
     77         document_graph = UDSDocumentGraph.from_dict(document, name)
---> 78         sent_graph_names = set(map(lambda node: node['semantics']['graph'], document['nodes']))
     79         sent_graphs = {}
     80         sent_ids = {}

KeyError: 'semantics'
```

The core of the issue is that we have somehow ended up with a number of cross-document mereology annotations (48 across all splits, by my count). Since nodes and edges in the document graph are dynamically constructed based on those annotations, we can thus end up with nodes in a document graph that do not belong there. For reasons that aren't worth explaining, these misfit nodes get added to the graph without the normal node attributes, including the `semantics` attribute, which is why we get this key error. But the bigger problem is that these nodes are being added at all.

This PR adds a check when adding document-level edge annotations to ensure both nodes incident on the annotated edge belong to sentences in the document. If at least one node does not belong to a sentence in the document, the annotation is skipped. I need to further investigate how we ended up with cross-document mereology annotations, but this is probably a check worth having anyway and can serve as a stopgap at the very least.

This also appears to affect only corpus loads with raw annotations, though I haven't yet figured out why.